### PR TITLE
Upgrade terraform-provider-aiven to v4.1.3

### DIFF
--- a/patches/0001-Add-shim.NewProvider-to-expose-internal-provider.New.patch
+++ b/patches/0001-Add-shim.NewProvider-to-expose-internal-provider.New.patch
@@ -21,8 +21,8 @@ index 0000000..e3d316a
 +	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 +)
 +
-+func NewProvider() *schema.Provider {
-+	return provider.Provider()
++func NewProvider(version string) *schema.Provider {
++	return provider.Provider(version)
 +}
 --
 2.39.1

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -67,7 +67,7 @@ func refProviderLicense(license tfbridge.TFProviderLicense) *tfbridge.TFProvider
 }
 
 func Provider() tfbridge.ProviderInfo {
-	p := shimv2.NewProvider(providerShim.NewProvider())
+	p := shimv2.NewProvider(providerShim.NewProvider(version.Version))
 
 	prov := tfbridge.ProviderInfo{
 		P:                 p,


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumi-aiven`.

---

Upgrading terraform-provider-aiven from 4.1.1 to 4.1.3.

Fixes #268
Fixes #266
