### PR TITLE
Enable gci linter and sort imports

### DIFF
--- a/.github/workflows/upgrade-bridge.yml
+++ b/.github/workflows/upgrade-bridge.yml
@@ -7,6 +7,11 @@ on:
       - upgrade-bridge
   workflow_dispatch:
     inputs:
+      kind:
+        description: Overrides the kind of upgrade. Must be one of `all`, `bridge`, `provider`, `code`, `pf`, or `pulumi`.
+        required: false
+        type: string
+        default: "bridge"
       target-bridge-version:
         description: pulumi-terraform-bridge version or hash reference
         required: false
@@ -50,7 +55,7 @@ jobs:
       if: github.event_name == 'workflow_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: bridge
+        kind: ${{ inputs.kind }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ inputs.automerge }}
@@ -62,7 +67,7 @@ jobs:
       if: github.event_name == 'repository_dispatch'
       uses: pulumi/pulumi-upgrade-provider-action@v0.0.11
       with:
-        kind: bridge
+        kind: ${{ inputs.kind }}
         email: bot@pulumi.com
         username: pulumi-bot
         automerge: ${{ github.event.client_payload.automerge }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,9 +18,19 @@ linters:
   - structcheck
   - unconvert
   - varcheck
+  - gci
   enable-all: false
 run:
   skip-files:
   - schema.go
   - pulumiManifest.go
   timeout: 20m
+linters-settings:
+  gci:
+    sections:
+      - standard # Standard section: captures all standard library packages.
+      - blank # Blank section: contains all blank imports.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/pulumi/) # Custom section: groups all imports with the github.com/pulumi/ prefix.
+      - prefix(github.com/pulumi/pulumi-aiven) # Custom section: local imports
+    custom-order: true

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,11 @@ install_plugins: .pulumi/bin/pulumi
 lint_provider: provider
 	cd provider && golangci-lint run -c ../.golangci.yml
 
+# `lint_provider.fix` is a utility target meant to be run manually
+# that will run the linter and fix errors when possible.
+lint_provider.fix:
+	cd provider && golangci-lint run -c ../.golangci.yml --fix
+
 # `make provider_no_deps` builds the provider binary directly, without ensuring that 
 # `cmd/pulumi-resource-aiven/schema.json` is valid and up to date. 
 # To create a release ready binary, you should use `make provider`.

--- a/provider/cmd/pulumi-resource-aiven/main.go
+++ b/provider/cmd/pulumi-resource-aiven/main.go
@@ -18,10 +18,12 @@ package main
 
 import (
 	"context"
+
 	_ "embed"
 
-	aiven "github.com/pulumi/pulumi-aiven/provider/v6"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+
+	aiven "github.com/pulumi/pulumi-aiven/provider/v6"
 )
 
 //go:embed schema-embed.json

--- a/provider/cmd/pulumi-tfgen-aiven/main.go
+++ b/provider/cmd/pulumi-tfgen-aiven/main.go
@@ -17,8 +17,9 @@ package main
 import (
 	"context"
 
-	aiven "github.com/pulumi/pulumi-aiven/provider/v6"
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfgen"
+
+	aiven "github.com/pulumi/pulumi-aiven/provider/v6"
 )
 
 func main() {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -17,18 +17,21 @@ package aiven
 import (
 	"context"
 	"fmt"
-	// embed is used to store bridge-metadata.json in the compiled binary
-	_ "embed"
 	"path/filepath"
 	"unicode"
 
+	// embed is used to store bridge-metadata.json in the compiled binary
+	_ "embed"
+
 	providerShim "github.com/aiven/terraform-provider-aiven/shim"
-	"github.com/pulumi/pulumi-aiven/provider/v6/pkg/version"
+
 	pfbridge "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	tfbridgetokens "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	"github.com/pulumi/pulumi-aiven/provider/v6/pkg/version"
 )
 
 // all of the token components used below.


### PR DESCRIPTION
This PR is part of a migration to standardize the order and grouping of our Go imports. See https://github.com/pulumi/upgrade-provider/pull/236.