### PR TITLE
Disable E2E tests on Aiven

### DIFF
--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+//go:build dotnet || all
 // +build dotnet all
 
 package examples
@@ -10,7 +11,7 @@ import (
 )
 
 func getCsharpBaseOptions(t *testing.T) integration.ProgramTestOptions {
-	base := getBaseOptions()
+	base := getBaseOptions(t)
 	baseCsharp := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
 			"Pulumi.Aiven",

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -31,7 +31,7 @@ func TestAccPgService(t *testing.T) {
 
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	projectName := getProjectName(t)
-	base := getBaseOptions()
+	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{
 		ExpectRefreshChanges: true,
 		Config: map[string]string{

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+//go:build python || all
 // +build python all
 
 package examples
@@ -11,7 +12,7 @@ import (
 )
 
 func getPythonBaseOptions(t *testing.T) integration.ProgramTestOptions {
-	base := getBaseOptions()
+	base := getBaseOptions(t)
 	basePython := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
 			filepath.Join("..", "sdk", "python", "bin"),

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -28,6 +28,9 @@ func getCwd(t *testing.T) string {
 }
 
 func getBaseOptions() integration.ProgramTestOptions {
+	t.Skip(`Testing for pulumi-aiven needs to be robust to resource leaks (#235).
+               In the past, we have leaked resources here, and continued E2E testing on this provider is not a priority
+	       so we have chosen to discontinue testing pulumi-aiven in CI.`)
 	return integration.ProgramTestOptions{
 		RunUpdateTest: false,
 	}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -27,7 +27,7 @@ func getCwd(t *testing.T) string {
 	return cwd
 }
 
-func getBaseOptions() integration.ProgramTestOptions {
+func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	t.Skip(`Testing for pulumi-aiven needs to be robust to resource leaks (#235).
                In the past, we have leaked resources here, and continued E2E testing on this provider is not a priority
 	       so we have chosen to discontinue testing pulumi-aiven in CI.`)


### PR DESCRIPTION
We've continued to see resource leaks on these tests and this provider is not high enough usage to merit automated E2E testing in CI.

Fixes #235 